### PR TITLE
fix Tree.get() to correctly return data

### DIFF
--- a/fmf/base.py
+++ b/fmf/base.py
@@ -72,7 +72,7 @@ class Tree(object):
 
     def get(self, name=None):
         """ Get desired attribute """
-        if name is not None:
+        if name is None:
             return self.data
         return self.data[name]
 


### PR DESCRIPTION
There was a bug where Tree.get() failed with 'KeyError: None'. Inverting the logic works as intended, with no name given return the whole dict, otherwise return only the atribute with name given.
