### PR TITLE
ability to add to parent atribute at child using '+' at the end

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -70,6 +70,18 @@ Metadata is inherited from parent objects::
 
 This nicely prevents unnecessary duplication.
 
+It is possible to add to existing metadata using '+'. This adds both values together.
+This operation is possible only on the same types, raises utils.TypeError if types are different.
+In these examples the values of 'time' attribute at 'download' are equal (time = 4)::
+
+    time: 1
+    /download:
+        time+: 3
+
+::
+
+    /download:
+        time: 4
 
 Elasticity
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/fmf/base.py
+++ b/fmf/base.py
@@ -59,6 +59,15 @@ class Tree(object):
         for key, value in sorted(data.iteritems()):
             if key.startswith('/'):
                 children[key.lstrip('/')] = value
+            elif key.endswith('+'):
+                # Warning: running three.grow() including the same path with attribute+ leads to adding the value twice!
+                try:
+                    if key.rstrip('+') in self.data:
+                        value = self.data[key.rstrip('+')] + value
+                    self.data[key.rstrip('+')] = value
+                except TypeError as e:
+                    raise utils.TypeError(
+                        "TypeError at '{0}': {1}.".format(self.name, e.message))
             else:
                 self.data[key] = value
 

--- a/fmf/utils.py
+++ b/fmf/utils.py
@@ -43,6 +43,9 @@ class FileError(GeneralError):
 class FilterError(GeneralError):
     """ Missing data when filtering """
 
+class TypeError(GeneralError):
+    """ Wrong data type between parent and child """
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Utils
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/.hidden/main.fmf
+++ b/tests/.hidden/main.fmf
@@ -1,0 +1,3 @@
+# FMF should not load this file
+
+tag: TIPpass

--- a/tests/.test.fmf
+++ b/tests/.test.fmf
@@ -1,0 +1,3 @@
+# FMF should not load this file
+
+tag: TIPpass

--- a/tests/main.fmf
+++ b/tests/main.fmf
@@ -1,0 +1,1 @@
+tag: Tier1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,11 +3,14 @@
 from __future__ import unicode_literals, absolute_import
 
 import pytest
-from fmf.utils import filter, FilterError
+from fmf.utils import filter, FilterError, FileError, TypeError
+from fmf.base import Tree
+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Filter
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 
 def test_filter():
     """ Function filter() """
@@ -63,3 +66,56 @@ def test_filter():
     filter("tag: ťip", data) == False
     filter("tag: ťip", {"tag": ["ťip"]}) == True
     filter("tag: -ťop", {"tag": ["ťip"]}) == True
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  Tree
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+def test_tree():
+    """ Class tree() """
+
+    with pytest.raises(FileError):
+        Tree("")
+
+    tree = Tree("tests/")
+
+    tree.update(None)
+    assert(".hidden" not in tree.children)
+    assert(".test" not in tree.children)
+
+    data = tree.data
+    assert(data["tag"] != "TIPpass")
+    assert(data["tag"] == "Tier1")
+    tree.update({"tag": ["Tier1", "TIPpass"], "time": 1, "desc": "Desc"})
+    data = tree.data
+    assert('TIPpass' in data['tag'])
+
+    # adding to attributes using '+'
+    tree.update({"tag+": ["test"], "time+": 2, "desc+": "some", "new+": "New"})
+    data = tree.data
+    assert("new+" not in data)
+    assert (data["new"] == "New")
+    assert("time+" not in data)
+    assert (data["time"] != 1)
+    assert (data["time"] == 3)
+    assert("desc+" not in data)
+    assert (data["desc"] != "Desc")
+    assert (data["desc"] == "Descsome")
+    assert("tag+" not in data)
+    assert("Add" not in data["tag"])
+    assert("Tier1" in data["tag"])
+    with pytest.raises(TypeError):
+        tree.update({"time+": "string"})
+
+    # tree.get()
+    isinstance(tree.get(), dict)
+    assert(not isinstance(tree.get("time"), type("")))
+    assert(isinstance(tree.get("time"), int))
+
+    # tree.show()
+    assert(not isinstance(tree.show(brief=True), dict))
+    assert(isinstance(tree.show(brief=True), type("")))
+    assert(not isinstance(tree.show(), dict))
+    assert(isinstance(tree.show(), type("")))


### PR DESCRIPTION
This code allows user to add value to inherited attribute.
If there is inherited attribute, it converts it to a list and appends the new value.

Example:
parent has attribute 'install_packages' with value 'this'
child has attribute 'install_packages+' with value 'that'
result is child having attribute 'install_packages' with value ['this', 'that']

This works with parent not having the attribute at all (the '+' is basically ignored), parent having value in attribute (value gets changed to list and new value is appended) and parent having value as list (new value is appended to the end)