### PR TITLE
Add docs example for setting up storage

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,4 +1,3 @@
-
 ======================
     Examples
 ======================
@@ -133,3 +132,47 @@ openscap using the Flexible Metadata Format::
             - openscap/scanning/oval
 
 __ https://github.com/dahaic/test-strategist
+
+
+Setups
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This example show how to use Flexible Metadata Format to
+run tests with different storage setups including cleanup.
+This is simplified metadata, whole example including tools
+can be found at storage_setup__::
+
+    /setups:
+        description: Tests to prepare and clean up devices for tests
+        setup: True
+        /setup_local:
+            test: setup_local.py
+            requires_cleanup: setups/cleanup_local
+        /cleanup_local:
+            test: cleanup_local.py
+        /setup_remote:
+            test: setup_remote.py
+            requires_cleanup: setups/cleanup_remote
+        /cleanup_remote:
+            test: cleanup_remote.py
+        /setup_vdo:
+            test: setup_vdo.py
+            requires_cleanup: setups/cleanup_vdo
+        /cleanup_vdo:
+            test: cleanup_vdo.py
+    /tests:
+        description: Testing 'vdo' command line tool
+        requires_setup: [setups/setup_*]
+        /create
+            description: Testing 'vdo create'
+            /ack_threads
+            /activate
+        /modify
+            description: Testing 'vdo modify'
+            requires_setup+: [setups/setup_vdo]
+            /block_map_cache_size
+
+__ https://github.com/jkrysl/storage_setup
+You can find here not only how to use FMF for setup/cleanup
+and group tests based on that, but also installing requirements,
+passing values from metadata to tests themself and much more.


### PR DESCRIPTION
Adding a new section to examples.rst with storage setup. It links to new [project on github](https://github.com/jkrysl/storage_setup), because it requires some extra tooling which should not be part of this project.