### PR TITLE
first draft of tool for output test formatting

### DIFF
--- a/fmf/output_interpreter.py
+++ b/fmf/output_interpreter.py
@@ -66,25 +66,26 @@ def formatstring(nodes, formatstring, values):
     return output
 
 
+def inspect_dirs(directories=None):
+    # TODO: replace this also in cli.py, it is very common case
+    if not directories:
+        directories = ["."]
+    output = list()
+    for one_dir in directories:
+        output.append(base.Tree(one_dir))
+    return output
+
 def main(cmdline=None):
     """ Parse options, gather metadata, print requested data """
 
     # Parse command line arguments
     options, arguments = ExtendOptions().parse(cmdline)
-    if not arguments:
-        arguments = ["."]
-    output = ""
-
-    # Show metadata for each path given
-    counter = 0
-    for path in arguments:
-        if options.verbose:
-            utils.info("Checking {0} for metadata.".format(path))
-        filtered = prune(base.Tree(path),
+    tree_object_list = inspect_dirs(directories=arguments)
+    for tree_object in tree_object_list:
+        filtered = prune(tree_object,
                           whole=options.whole,
                           keys=options.keys,
                           names=options.names,
                           filters=options.filters)
-
         formatted = formatstring(filtered, options.formatstring, options.values)
         print(os.linesep.join(formatted))

--- a/fmf/output_interpreter.py
+++ b/fmf/output_interpreter.py
@@ -1,0 +1,90 @@
+# coding: utf-8
+
+"""
+Command line interface for Flexible Metadata Format
+
+This module takes care of processing command line options
+and providing requested output.
+"""
+
+import os
+import utils
+import base
+import re
+from cli import Options
+
+
+# set  of functions to use for evaluation
+from os.path import basename, dirname, curdir
+from os import getcwd
+
+
+class ExtendOptions(Options):
+    def __init__(self):
+        super(ExtendOptions, self).__init__()
+        group = self.parser.add_argument_group("Output Formatter")
+        group.add_argument(
+            "--value", dest="values", action="append", default=[],
+            help="value to formatting string, position dependent, symbol {} in string")
+        group.add_argument(
+            "--formatstring", dest="formatstring", action="store",
+            help="Basic formatting string, use python syntax like {} or {1} to replacements")
+
+
+def prune(tree, whole, keys, names, filters):
+    #TODO: if accepted, replace also this in cli.py or to utils and then use it also in cli
+    output = []
+    for node in tree.climb(whole):
+        # Select only nodes with key content
+        if not all([key in node.data for key in keys]):
+            continue
+        # Select nodes with name matching regular expression
+        if names and not any(
+                [re.search(name, node.name) for name in names]):
+            continue
+        # Apply advanced filters if given
+        try:
+            if not all([utils.filter(filter, node.data)
+                        for filter in filters]):
+                continue
+        # Handle missing attribute as if filter failed
+        except utils.FilterError:
+            continue
+        output.append(node)
+    return output
+
+def formatstring(nodes, formatstring, values):
+    output = []
+    for node in nodes:
+        evaluated = []
+        # used internally to avoid using long syntax like name -> node.name data[key] -> node.data[key]
+        name = node.name
+        data = node.data
+        for value in values:
+            evaluated.append(eval(value))
+        output.append(formatstring.format(*evaluated))
+    return output
+
+
+def main(cmdline=None):
+    """ Parse options, gather metadata, print requested data """
+
+    # Parse command line arguments
+    options, arguments = ExtendOptions().parse(cmdline)
+    if not arguments:
+        arguments = ["."]
+    output = ""
+
+    # Show metadata for each path given
+    counter = 0
+    for path in arguments:
+        if options.verbose:
+            utils.info("Checking {0} for metadata.".format(path))
+        filtered = prune(base.Tree(path),
+                          whole=options.whole,
+                          keys=options.keys,
+                          names=options.names,
+                          filters=options.filters)
+
+        formatted = formatstring(filtered, options.formatstring, options.values)
+        print(os.linesep.join(formatted))

--- a/fmf/output_interpreter.py
+++ b/fmf/output_interpreter.py
@@ -25,7 +25,9 @@ class ExtendOptions(Options):
         group = self.parser.add_argument_group("Output Formatter")
         group.add_argument(
             "--value", dest="values", action="append", default=[],
-            help="value to formatting string, position dependent, symbol {} in string")
+            help="""value to formatting string, position dependent, symbol {} in string,
+(possible functions: basename, dirname, curdir, getcwd)"
+usages --value name    , --value 'dirname(data["path"])'""")
         group.add_argument(
             "--formatstring", dest="formatstring", action="store", required=True,
             help="Basic formatting string, use python syntax like {} or {1} to replacements")
@@ -53,6 +55,7 @@ def prune(tree, whole, keys, names, filters):
         output.append(node)
     return output
 
+
 def formatstring(nodes, formatstring, values):
     output = []
     for node in nodes:
@@ -74,6 +77,7 @@ def inspect_dirs(directories=None):
     for one_dir in directories:
         output.append(base.Tree(one_dir))
     return output
+
 
 def main(cmdline=None):
     """ Parse options, gather metadata, print requested data """

--- a/fmf/output_interpreter.py
+++ b/fmf/output_interpreter.py
@@ -27,7 +27,7 @@ class ExtendOptions(Options):
             "--value", dest="values", action="append", default=[],
             help="value to formatting string, position dependent, symbol {} in string")
         group.add_argument(
-            "--formatstring", dest="formatstring", action="store",
+            "--formatstring", dest="formatstring", action="store", required=True,
             help="Basic formatting string, use python syntax like {} or {1} to replacements")
 
 
@@ -77,7 +77,7 @@ def inspect_dirs(directories=None):
 
 def main(cmdline=None):
     """ Parse options, gather metadata, print requested data """
-
+    output = []
     # Parse command line arguments
     options, arguments = ExtendOptions().parse(cmdline)
     tree_object_list = inspect_dirs(directories=arguments)
@@ -88,4 +88,6 @@ def main(cmdline=None):
                           names=options.names,
                           filters=options.filters)
         formatted = formatstring(filtered, options.formatstring, options.values)
-        print(os.linesep.join(formatted))
+        output += formatted
+    print(os.linesep.join(output))
+    return output

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,11 @@ default_setup = dict(
     provides=__provides__,
     scripts=__scripts__,
     version=__version__,
+    entry_points={
+        'console_scripts': [
+            'fmf-output = fmf.output_interpreter:main'
+        ]
+    },
 )
 
 setup(**default_setup)

--- a/tests/test_cli_fmf_output.py
+++ b/tests/test_cli_fmf_output.py
@@ -1,0 +1,59 @@
+# coding: utf-8
+
+from __future__ import unicode_literals, absolute_import
+
+import os
+import fmf.output_interpreter as cli
+
+# Prepare path to examples
+PATH = os.path.dirname(os.path.realpath(__file__))
+WGET = PATH + "/../examples/wget"
+
+
+class TestCommandLine(object):
+    """ Command Line """
+
+    def test_noargs(self):
+        """ Smoke test """
+        try:
+            cli.main("")
+        except SystemExit:
+            pass
+        else:
+            raise BaseException("required at least format string argument, without this it does not make sense")
+
+    def test_smoke_generic_no_value(self):
+        assert "ahoj" in cli.main(WGET + " --key test --formatstring ahoj")
+
+    def test_smoke_generic(self):
+        assert "wget/download/test" in cli.main(WGET + " --key test --formatstring {} --value name")
+
+class TestAPI(object):
+    """ Test API """
+    def test_smoke(self):
+        tree_object_list = cli.inspect_dirs(directories=[WGET])
+        for tree_object in tree_object_list:
+            filtered = cli.prune(tree_object, keys=["test"], whole=False, names=[], filters=[])
+            formatted = cli.formatstring(filtered, "{}", ["name"])
+            assert "wget/download/test" in formatted
+
+    def test_smoke_default_dir(self):
+        tree_object_list = cli.inspect_dirs()
+        tree_object = tree_object_list[0]
+        assert tree_object.name
+
+        filtered = cli.prune(tree_object, keys=["test"], whole=False, names=[], filters=[])
+        assert filtered
+
+        filtered = cli.prune(tree_object, keys=[], whole=False, names=["test"], filters=[])
+        assert filtered
+
+        filtered = cli.prune(tree_object, keys=[], whole=False, names=[], filters=["tag: test"])
+        assert not filtered
+
+        filtered = cli.prune(tree_object, keys=[], whole=False, names=[], filters=["test"])
+        assert not filtered
+
+
+
+


### PR DESCRIPTION
* able to format output string for scheduler command:

## Usages

### generic
 * ``fmf-output --key test --formatstring "dir:{} test:{}" --value "data.get('path') or name" --value "data['test']"` ``
```
dir:fmf/examples/wget/download/test test:runtest.sh
dir:fmf/examples/wget/recursion/fast test:runtest.sh
dir:fmf/examples/wget/recursion/deep test:runtest.sh
dir:fmf/examples/wget/protocols/ftp test:runtest.sh
dir:fmf/examples/wget/protocols/http test:runtest.sh
dir:fmf/examples/wget/protocols/https test:runtest.sh
```

### avocado command line
 *  ``echo avocado run `fmf-output --key test --formatstring "{}/{}/{}" --value "getcwd()" --value "data.get('path') or name" --value "data['test']"` `` produces:
```
avocado run /home/jscotka/git/fmf/fmf/examples/wget/download/test/runtest.sh /home/jscotka/git/fmf/fmf/examples/wget/recursion/fast/runtest.sh /home/jscotka/git/fmf/fmf/examples/wget/recursion/deep/runtest.sh /home/jscotka/git/fmf/fmf/examples/wget/protocols/ftp/runtest.sh /home/jscotka/git/fmf/fmf/examples/wget/protocols/http/runtest.sh /home/jscotka/git/fmf/fmf/examples/wget/protocols/https/runtest.sh
 ```
### beaker like line usage
 * ``echo bkr workflow-tomorrow `fmf-output --key test --formatstring "--task '{} /CoreOS/{}'" --value "data.get('params') or ''" --value "name"` `` produces:
```
bkr workflow-tomorrow --task ' /CoreOS/fmf/examples/wget/download/test' --task ' /CoreOS/fmf/examples/wget/recursion/fast' --task ' /CoreOS/fmf/examples/wget/recursion/deep' --task ' /CoreOS/fmf/examples/wget/protocols/ftp' --task ' /CoreOS/fmf/examples/wget/protocols/http' --task ' /CoreOS/fmf/examples/wget/protocols/https'
```



