### PR TITLE
Add prefix value to Tree class

### DIFF
--- a/fmf/base.py
+++ b/fmf/base.py
@@ -40,8 +40,10 @@ class Tree(object):
         self.data = dict()
         if name is None:
             self.name = os.path.basename(os.path.realpath(data))
+            self.prefix = os.path.dirname(os.path.realpath(data))
         else:
             self.name = "/".join([self.parent.name, name])
+            self.prefix = self.parent.prefix
 
         # Inherit data from parent
         if self.parent is not None:
@@ -187,6 +189,7 @@ class Tree(object):
             formatting = re.sub("\\\\n", "\n", formatting)
             name = self.name
             data = self.data
+            prefix = self.prefix
             evaluated = []
             for value in values:
                 evaluated.append(eval(value))


### PR DESCRIPTION
it solves issue, that it is unable to find absolute path to actual tree item.
 * example output: ``fmf --format "{}: {}\n" --value name --value prefix examples/wget/recursion examples/merge``
```
recursion/fast: /home/jscotka/git/fmf/examples/wget
recursion/deep: /home/jscotka/git/fmf/examples/wget
merge/parent/child: /home/jscotka/git/fmf/examples
```
 *  with **.** path:  ``fmf --key test --format "{}: {}\n" --value name --value prefix .``
```
fmf/examples/wget/download/test: /home/jscotka/git
fmf/examples/wget/recursion/fast: /home/jscotka/git
fmf/examples/wget/recursion/deep: /home/jscotka/git
fmf/examples/wget/protocols/ftp: /home/jscotka/git
fmf/examples/wget/protocols/http: /home/jscotka/git
fmf/examples/wget/protocols/https: /home/jscotka/git
```

