### PR TITLE
fmf/cli.py: fix `os.path.dirname`  example invocation

### DIFF
--- a/fmf/cli.py
+++ b/fmf/cli.py
@@ -18,7 +18,7 @@ variable 'name' contains the object identifier. Python modules 'os' and
 'os.path' are available as well and can be used for processing attribute
 values as desired:
 
-    fmf --format '{}' --value 'os.dirname(data["path"])'
+    fmf --format '{}' --value 'os.path.dirname(data["path"])'
 
 See online documentation for more details and examples:
 


### PR DESCRIPTION
`dirname()` lives under `os.path` module, not under `os` directly.

Signed-off-by: Cleber Rosa <crosa@redhat.com>