### PR TITLE
Encode stdout as UTF-8 [#21]

### DIFF
--- a/fmf/cli.py
+++ b/fmf/cli.py
@@ -124,7 +124,7 @@ def main(cmdline=None):
             show = node.show(
                 options.brief, options.formatting, options.values)
             if show is not None:
-                print(show, end="")
+                print(show.encode('utf-8'), end="")
                 output += show
                 counter += 1
     # Print summary


### PR DESCRIPTION
Just the simplest change to fix #21.

There might be other places where I/O encoding needs fixing; feel free to supersede this PR.