### PR TITLE
[WIP] Ensure inheritance of all parent data no matter where

### DIFF
--- a/examples/inheritance/one.fmf
+++ b/examples/inheritance/one.fmf
@@ -1,0 +1,5 @@
+one_root: 1
+/two:
+  two_root: 1
+/two/three:
+  three_root: 1

--- a/examples/inheritance/one/main.fmf
+++ b/examples/inheritance/one/main.fmf
@@ -1,0 +1,5 @@
+one: 1
+/two:
+  two: 1
+/two/three:
+  three: 1

--- a/fmf/base.py
+++ b/fmf/base.py
@@ -82,9 +82,6 @@ class Tree(object):
 
         # Handle child attributes
         for name, data in sorted(children.items()):
-            # ensure inheritance of direct parent data
-            if data is not None and self.parent is not None:
-                data.update(copy.deepcopy(self.parent.data))
             # Handle deeper nesting (e.g. keys like /one/two/three) by
             # extracting only the first level of the hierarchy as name
             match = re.search("([^/]+)(/.*)", name)
@@ -93,6 +90,8 @@ class Tree(object):
                 data = {match.groups()[1]: data}
             # Update existing child or create a new one
             try:
+                if data is not None:
+                    data.update(self.data)
                 self.children[name].update(data)
             except KeyError:
                 self.children[name] = Tree(
@@ -150,9 +149,6 @@ class Tree(object):
             log.data(pretty(data))
             if filename == MAIN:
                 self.sources.append(fullpath)
-                # Ensure inheriting all ancestors data
-                if data is not None and self.parent is not None:
-                    data.update(copy.deepcopy(self.parent.data))
                 self.update(data)
             else:
                 self.child(os.path.splitext(filename)[0], data, fullpath)

--- a/fmf/base.py
+++ b/fmf/base.py
@@ -82,6 +82,9 @@ class Tree(object):
 
         # Handle child attributes
         for name, data in sorted(children.items()):
+            # ensure inheritance of direct parent data
+            if data is not None and self.parent is not None:
+                data.update(copy.deepcopy(self.parent.data))
             # Handle deeper nesting (e.g. keys like /one/two/three) by
             # extracting only the first level of the hierarchy as name
             match = re.search("([^/]+)(/.*)", name)
@@ -147,6 +150,9 @@ class Tree(object):
             log.data(pretty(data))
             if filename == MAIN:
                 self.sources.append(fullpath)
+                # Ensure inheriting all ancestors data
+                if data is not None and self.parent is not None:
+                    data.update(copy.deepcopy(self.parent.data))
                 self.update(data)
             else:
                 self.child(os.path.splitext(filename)[0], data, fullpath)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -28,6 +28,7 @@ class TestTree(object):
         """ Load examples """
         self.wget = Tree(EXAMPLES + "wget")
         self.merge = Tree(EXAMPLES + "merge")
+        self.inheritance = Tree(EXAMPLES + "inheritance")
 
     def test_basic(self):
         """ No directory path given """
@@ -44,6 +45,13 @@ class TestTree(object):
         assert(deep.data['depth'] == 1000)
         assert(deep.data['description'] == 'Check recursive download options')
         assert(deep.data['tags'] == ['Tier2'])
+
+    def test_complete_inheritance(self):
+        """ Test hierarchy across the whole tree """
+        inheritance = self.inheritance.find("inheritance/one/two/three")
+        for data in "one one_root two two_root three three_root".split():
+            assert(data in inheritance.data)
+            assert(inheritance.data[data] == 1)
 
     def test_deep_hierarchy(self):
         """ Deep hierarchy on one line """


### PR DESCRIPTION
Fixes issue #25 

I did not find a way to fix this without the duplication. It does not work using only one of them (or moving the 2nd from MAIN file loading). The one in MAIN file loading is for inheritance through the tree while the one in update() is for direct inheritance from the parent.