### PR TITLE
Adjust 'make test' to work under virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,11 @@ tmp:
 
 # Run the test suite, optionally with coverage
 test: tmp
-	python2 -m pytest tests
-	python3 -m pytest tests
+	pytest tests/unit -c tests/unit/pytest.ini
 smoke: tmp
-	python2 -m pytest tests/test_smoke.py
-	python3 -m pytest tests/test_smoke.py
+	pytest tests/unit/test_smoke.py -c tests/unit/pytest.ini
 coverage: tmp
-	coverage run --source=fmf,bin -m py.test tests
+	coverage run --source=fmf,bin -m py.test -c tests/unit/pytest.ini tests
 	coverage report
 	coverage annotate
 

--- a/tests/unit/pytest.ini
+++ b/tests/unit/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    web: tests which need to access the web


### PR DESCRIPTION
Explicitly provide pytest config to suppress warnings.