### PR TITLE
Use locking to checkout/read tree

### DIFF
--- a/fmf.spec
+++ b/fmf.spec
@@ -49,10 +49,10 @@ BuildRequires: python2-devel
 BuildRequires: python2-setuptools
 BuildRequires: pytest
 BuildRequires: PyYAML
-BuildRequires: python2-lockfile
+BuildRequires: python2-filelock
 %{?python_provide:%python_provide python2-%{name}}
 Requires:       PyYAML
-Requires:       python2-lockfile
+Requires:       python2-filelock
 
 %description -n python2-%{name}
 The fmf Python module and command line tool implement a flexible
@@ -71,12 +71,12 @@ BuildRequires: python%{python3_pkgversion}-devel
 BuildRequires: python%{python3_pkgversion}-setuptools
 BuildRequires: python%{python3_pkgversion}-pytest
 BuildRequires: python%{python3_pkgversion}-PyYAML
-BuildRequires: python%{python3_pkgversion}-lockfile
+BuildRequires: python%{python3_pkgversion}-filelock
 BuildRequires: git-core
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{name}}
 %if %{with oldreqs}
 Requires:       python%{python3_pkgversion}-PyYAML
-Requires:       python%{python3_pkgversion}-lockfile
+Requires:       python%{python3_pkgversion}-filelock
 %endif
 
 %description -n python%{python3_pkgversion}-%{name}

--- a/fmf.spec
+++ b/fmf.spec
@@ -49,8 +49,10 @@ BuildRequires: python2-devel
 BuildRequires: python2-setuptools
 BuildRequires: pytest
 BuildRequires: PyYAML
+BuildRequires: python2-lockfile
 %{?python_provide:%python_provide python2-%{name}}
 Requires:       PyYAML
+Requires:       python2-lockfile
 
 %description -n python2-%{name}
 The fmf Python module and command line tool implement a flexible
@@ -69,10 +71,12 @@ BuildRequires: python%{python3_pkgversion}-devel
 BuildRequires: python%{python3_pkgversion}-setuptools
 BuildRequires: python%{python3_pkgversion}-pytest
 BuildRequires: python%{python3_pkgversion}-PyYAML
+BuildRequires: python%{python3_pkgversion}-lockfile
 BuildRequires: git-core
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{name}}
 %if %{with oldreqs}
 Requires:       python%{python3_pkgversion}-PyYAML
+Requires:       python%{python3_pkgversion}-lockfile
 %endif
 
 %description -n python%{python3_pkgversion}-%{name}

--- a/fmf/utils.py
+++ b/fmf/utils.py
@@ -536,14 +536,15 @@ def fetch(url, ref=None, destination=None, env=None):
             try:
                 os.makedirs(cache)
             except OSError as error:
-                # python2 doesn't have exist_ok=True, emulating it here
-                # we don't care if cache wasn't created by this process
+                # Python 2 doesn't have exist_ok=True, emulating it here.
+                # We don't care if cache wasn't created by this process.
                 # errno-17 is file exists
                 if error.errno == 17 and os.path.isdir(fmf_cache):
                     pass
                 else:
                     raise GeneralError(
-                        "Failed to create cache directory '{0}'.".format(cache))
+                        "Failed to create cache directory '{0}'.".format(
+                            cache))
         directory = url.replace('/', '_')
         destination = os.path.join(cache, directory)
     else:
@@ -553,20 +554,24 @@ def fetch(url, ref=None, destination=None, env=None):
     if ref is None:
         ref = '__DEFAULT__'
 
-    # lock for possibly shared cache directory, it has .lock extension automatically
-    # all in with statement to correctly remove lock on exception
-    log.debug("Acquire lock for {0}".format(destination))
+    # Lock for possibly shared cache directory, it has the '.lock'
+    # extension added automatically. Everything under the with statement
+    # to correctly remove lock upon exception.
+    log.debug("Acquire lock for '{0}'.".format(destination))
     try:
         with LockFile(destination, timeout=FETCH_LOCK_TIMEOUT) as lock:
-            # write own PID into lockfile to be able to investigate which process got it
-            with open(lock.lock_file, 'w') as fw:
-                fw.write(str(os.getpid()))
+            # Write own PID into lockfile to be able to investigate
+            # which process got it
+            with open(lock.lock_file, 'w') as lock_file:
+                lock_file.write(str(os.getpid()))
             # Clone the repository
             if not os.path.isdir(os.path.join(destination, '.git')):
                 run(['git', 'clone', url, destination], cwd=cache, env=env)
                 # Store the default branch from the origin as a DEFAULT ref
-                head = os.path.join(destination, '.git/refs/remotes/origin/HEAD')
-                default = os.path.join(destination, '.git/refs/heads/__DEFAULT__')
+                head = os.path.join(
+                    destination, '.git/refs/remotes/origin/HEAD')
+                default = os.path.join(
+                    destination, '.git/refs/heads/__DEFAULT__')
                 shutil.copyfile(head, default)
             # Fetch changes if we are too old
             fetch_head_file = os.path.join(destination, '.git', 'FETCH_HEAD')
@@ -585,7 +590,8 @@ def fetch(url, ref=None, destination=None, env=None):
     except (OSError, subprocess.CalledProcessError) as error:
         raise GeneralError("{0}".format(error))
     except LockTimeout:
-        raise GeneralError("Failed to acquire lock for {0} within {1} seconds".format(
+        raise GeneralError(
+            "Failed to acquire lock for '{0}' within {1} seconds.".format(
             destination, FETCH_LOCK_TIMEOUT))
 
     return destination

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ __desc__ = 'Flexible Metadata Format'
 __scripts__ = ['bin/fmf']
 __irequires__ = [
     'PyYAML',
+    'lockfile'
 ]
 
 pip_src = 'https://pypi.python.org/packages/source'

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ __desc__ = 'Flexible Metadata Format'
 __scripts__ = ['bin/fmf']
 __irequires__ = [
     'PyYAML',
-    'lockfile'
+    'filelock'
 ]
 
 pip_src = 'https://pypi.python.org/packages/source'

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -297,14 +297,15 @@ class TestRemote(object):
         q = queue.Queue()
         threads = []
         for i in range(10):
-            # args varies based on current thread index
-            threads.append(threading.Thread(target=get_node,
-                args=(possible_refs[i%len(possible_refs)],)))
+            # Arguments vary based on current thread index
+            threads.append(threading.Thread(
+                target=get_node,
+                args=(possible_refs[i % len(possible_refs)],)))
         for t in threads:
             t.start()
         for t in threads:
             t.join()
-        # for number of threads check their results
+        # For number of threads check their results
         all_good = True
         for t in threads:
             value = q.get()


### PR DESCRIPTION
Todo:
1. Figure out timeout and retries (if repo is too large...)
2. What to do with stale lock and how to detect it?
3. Test for `Tree.node` as one needs to force git pull (otherwise it all happens too fast)

But please review the concept (resolves #96)
Two locks
1. To read tree (request for ref and read are atomic)
2. To fetch (clone /fetch and checkout are atomic)