### PR TITLE
Use the origin default branch instead of master

### DIFF
--- a/docs/concept.rst
+++ b/docs/concept.rst
@@ -134,7 +134,7 @@ url
 ref
     Branch, tag or commit specifying the desired git revision.
     This is used to perform a ``git checkout`` in the repository.
-    Optional, by default the ``master`` branch is used.
+    If not provided, the ``default branch`` is used.
 path
     Path to the metadata tree root. Should be relative to the git
     repository root if ``url`` provided, absolute local filesystem
@@ -152,7 +152,7 @@ Here's a full fmf identifier example::
     name: /download/test
 
 Use default values for ``ref`` and ``path`` to reference the
-latest version of the smoke plan from the ``master`` branch::
+latest version of the smoke plan from the default branch::
 
     url: https://github.com/psss/fmf
     name: /plans/smoke

--- a/fmf/base.py
+++ b/fmf/base.py
@@ -545,7 +545,7 @@ class Tree(object):
         Keys supported in the reference:
 
         url .... git repository url (optional)
-        ref .... branch, tag or commit ('master' by default)
+        ref .... branch, tag or commit (default branch if not provided)
         path ... metadata tree root ('.' by default)
         name ... tree node name ('/' by default)
 
@@ -558,7 +558,7 @@ class Tree(object):
         if 'url' in reference:
             path = reference.get('path', '.').lstrip('/')
             repository = utils.fetch(
-                reference.get('url'), reference.get('ref', 'master'))
+                reference.get('url'), reference.get('ref'))
             root = os.path.join(repository, path)
         # Use local files
         else:


### PR DESCRIPTION
Instead of `master` let's use the default branch from the origin
if `ref` is not provided when fetching remote repositories. Plus
a minor update of the run() function to improve debugging.