### PR TITLE
Enable integration testing with tmt, some cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
-tmp
 build
 dist
-
 *.egg
 *.egg-info
-
 .pytest_cache
+*,cover
+.coverage
+/tmp/
+docs/_build
+docs/spec
+docs/stories
+__pycache__

--- a/plans/docs.fmf
+++ b/plans/docs.fmf
@@ -1,8 +1,0 @@
-summary:
-    Ensure that documentation is present
-discover:
-    how: fmf
-    repository: https://github.com/psss/fmf
-    filter: coverage:/stories/docs.*
-execute:
-    how: beakerlib

--- a/plans/features.fmf
+++ b/plans/features.fmf
@@ -1,7 +1,4 @@
 summary:
-    Essential command line features
+    Verify command line features
 discover:
     how: fmf
-    repository: https://github.com/psss/fmf
-execute:
-    how: beakerlib

--- a/plans/integration.fmf
+++ b/plans/integration.fmf
@@ -1,0 +1,10 @@
+summary:
+    Run integration tests with tmt
+discover:
+    how: fmf
+    url: https://github.com/psss/tmt
+    ref: fedora
+    filter: 'tier: 1, 2'
+prepare:
+    how: install
+    package: tmt-all

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -1,0 +1,15 @@
+# Run on localhost by default
+provision:
+    how: local
+
+# Use the internal executor
+execute:
+    how: tmt
+
+# Install packages
+#prepare:
+#  - name: fmf
+#    how: install
+#    package: fmf
+#    copr: psss/fmf
+#    directory: tmp/RPMS/noarch

--- a/tests/main.fmf
+++ b/tests/main.fmf
@@ -1,1 +1,2 @@
 test: ./test.sh
+framework: beakerlib


### PR DESCRIPTION
Create a new integration plan for tmt.
Remove old execute step methods.
Update .gitignore list.