### PR TITLE
Fetch whole tree using utils.get_remote_tree

### DIFF
--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -344,7 +344,7 @@ class TestRemote(object):
 
     def test_tree_concurrent_timeout(self, monkeypatch, tmpdir):
         # Much shorter timeout
-        monkeypatch.setattr('fmf.base.NODE_LOCK_TIMEOUT', 2)
+        monkeypatch.setattr('fmf.utils.NODE_LOCK_TIMEOUT', 2)
 
         def long_fetch(*args, **kwargs):
             # Longer than timeout


### PR DESCRIPTION
Moved fetching of the tree to utils, closer to where it belongs. Tree.node just uses this function,

Main main goal is to use this function from wow (and cache results) so fmf seems a better place to take care of locking (as should operate on fmf cache).

