### PR TITLE
A bunch of adjustments for the epel-7 build

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -18,6 +18,7 @@ jobs:
       targets:
       - fedora-all
       - epel-8
+      - epel-7
 
   - job: copr_build
     trigger: commit

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ man: source
 
 
 # RPM packaging
-source: clean
+source: clean tmp
 	mkdir -p $(TMP)/SOURCES
 	mkdir -p $(TMP)/$(PACKAGE)
 	cp -a $(FILES) $(TMP)/$(PACKAGE)

--- a/fmf.spec
+++ b/fmf.spec
@@ -28,7 +28,11 @@ Source0: https://github.com/psss/fmf/releases/download/%{version}/fmf-%{version}
 %endif
 
 # Main tmt package requires the Python module
+%if %{with python2}
+Requires: python2-%{name} == %{version}-%{release}
+%else
 Requires: python%{python3_pkgversion}-%{name} == %{version}-%{release}
+%endif
 
 %description
 The fmf Python module and command line tool implement a flexible
@@ -50,9 +54,13 @@ BuildRequires: python2-setuptools
 BuildRequires: pytest
 BuildRequires: PyYAML
 BuildRequires: python2-filelock
+BuildRequires: python2-six
+BuildRequires: git-core
 %{?python_provide:%python_provide python2-%{name}}
 Requires:       PyYAML
 Requires:       python2-filelock
+Requires:       python2-six
+Requires:       git-core
 
 %description -n python2-%{name}
 The fmf Python module and command line tool implement a flexible
@@ -61,7 +69,7 @@ stored close to the source code. Thanks to hierarchical structure
 with support for inheritance and elasticity it provides an
 efficient way to organize data into well-sized text documents.
 This package contains the Python 2 module.
-%endif
+%else
 
 
 # Python 3
@@ -74,6 +82,7 @@ BuildRequires: python%{python3_pkgversion}-PyYAML
 BuildRequires: python%{python3_pkgversion}-filelock
 BuildRequires: git-core
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{name}}
+Requires:       git-core
 %if %{with oldreqs}
 Requires:       python%{python3_pkgversion}-PyYAML
 Requires:       python%{python3_pkgversion}-filelock
@@ -86,6 +95,7 @@ stored close to the source code. Thanks to hierarchical structure
 with support for inheritance and elasticity it provides an
 efficient way to organize data into well-sized text documents.
 This package contains the Python 3 module.
+%endif
 
 
 %prep
@@ -99,9 +109,9 @@ export LANG=en_US.utf-8
 
 %if %{with python2}
 %py2_build
-%endif
-
+%else
 %py3_build
+%endif
 
 
 %install
@@ -111,9 +121,9 @@ export LANG=en_US.utf-8
 
 %if %{with python2}
 %py2_install
-%endif
-
+%else
 %py3_install
+%endif
 
 mkdir -p %{buildroot}%{_mandir}/man1
 install -pm 644 fmf.1* %{buildroot}%{_mandir}/man1
@@ -126,9 +136,9 @@ export LANG=en_US.utf-8
 
 %if %{with python2}
 %{__python2} -m pytest -vv -m 'not web'
-%endif
-
+%else
 %{__python3} -m pytest -vv -m 'not web'
+%endif
 
 
 %{!?_licensedir:%global license %%doc}
@@ -144,12 +154,12 @@ export LANG=en_US.utf-8
 %{python2_sitelib}/%{name}/
 %{python2_sitelib}/%{name}-*.egg-info
 %license LICENSE
-%endif
-
+%else
 %files -n python%{python3_pkgversion}-%{name}
 %{python3_sitelib}/%{name}/
 %{python3_sitelib}/%{name}-*.egg-info
 %license LICENSE
+%endif
 
 
 %changelog

--- a/fmf/base.py
+++ b/fmf/base.py
@@ -53,7 +53,7 @@ def unique_key_constructor(loader, node, deep=False):
         value = loader.construct_object(value_node, deep=deep)
         if key in mapping:
             raise yaml.constructor.ConstructorError(
-                f"Duplicate key '{key}' detected.")
+                "Duplicate key '{}' detected.".format(key))
         mapping[key] = value
     return loader.construct_mapping(node, deep)
 
@@ -687,5 +687,5 @@ class Tree(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         """ Experimental: Store modified metadata to disk """
         _, full_data, source = self._locate_raw_data()
-        with open(source, "w") as file:
+        with open(source, "w", encoding='utf-8') as file:
             file.write(dict_to_yaml(full_data))

--- a/tests/basic/test.sh
+++ b/tests/basic/test.sh
@@ -5,7 +5,7 @@
 
 # Run all phases by default
 phase=${1:-all}
-examples="/usr/share/doc/fmf/examples/wget"
+examples=$(ls -d /usr/share/doc/fmf*/examples/wget)
 
 rlJournalStart
     rlPhaseStartSetup

--- a/tests/docs/test.sh
+++ b/tests/docs/test.sh
@@ -4,7 +4,7 @@
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
 PACKAGE="fmf"
-EXAMPLES="/usr/share/doc/fmf/examples"
+EXAMPLES=$(ls -d /usr/share/doc/fmf*/examples)
 
 rlJournalStart
     rlPhaseStartSetup

--- a/tests/unit/main.fmf
+++ b/tests/unit/main.fmf
@@ -1,0 +1,13 @@
+summary: Python unit tests
+description:
+    Run all available python unit tests using pytest.
+test: python3 -m pytest -v
+framework: shell
+require:
+  - python3-pytest
+tier: 0
+
+adjust:
+    test: python2 -m pytest -v
+    require: python2-pytest
+    when: distro == rhel-7, centos-7

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -6,12 +6,16 @@ import os
 import pytest
 import time
 import threading
-import queue
 import tempfile
 import fmf.utils as utils
 import fmf.cli
 from fmf.base import Tree
 from shutil import rmtree
+
+try:
+    import queue
+except ImportError:
+    import Queue as queue
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -299,6 +303,7 @@ class TestRemote(object):
         with pytest.raises(utils.ReferenceError):
             Tree.node(dict(path='some/relative/path'))
 
+    @pytest.mark.web
     def test_tree_commit(self, tmpdir):
         # Tag
         node = Tree.node(dict(url=FMF_REPO, ref='0.12'))
@@ -311,9 +316,10 @@ class TestRemote(object):
         node = Tree(dict(x=1))
         assert node.commit is False
         # No git repository
-        tree = Tree(Tree.init(tmpdir))
+        tree = Tree(Tree.init(str(tmpdir)))
         assert tree.commit is False
 
+    @pytest.mark.web
     def test_tree_concurrent(self):
         def get_node(ref):
             try:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -105,6 +105,7 @@ class TestCommandLine(object):
         assert "deep" in output
         assert "/recursion" not in output
 
+    @pytest.mark.skipif(os.geteuid() == 0, reason="Running as root")
     def test_init(self):
         """ Initialize metadata tree """
         path = tempfile.mkdtemp()

--- a/tests/unit/test_modify.py
+++ b/tests/unit/test_modify.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals, absolute_import
 
 import unittest
 import pytest
+import io
 import os
 import re
 import tempfile
@@ -144,3 +145,14 @@ class TestModify(unittest.TestCase):
         self.assertIn('tester', node.data)
         self.assertIn('requirement', node.data)
         self.assertIn("server", node.data)
+
+    def test_modify_unicode(self):
+        """ Ensure that unicode characters are properly handled """
+        path = os.path.join(self.tempdir, 'unicode.fmf')
+        with io.open(path, 'w', encoding='utf-8') as file:
+            file.write('jméno: Leoš')
+        with Tree(self.tempdir).find('/unicode') as data:
+            data['příjmení'] = 'Janáček'
+        reloaded = Tree(self.tempdir).find('/unicode')
+        assert reloaded.get('jméno') == 'Leoš'
+        assert reloaded.get('příjmení') == 'Janáček'


### PR DESCRIPTION
Enable the `epel-7` target in packit.
Build only the `python2-fmf` package for rhel-7.
Resolve several Python 2 incompatibilities.
Enable unit tests, correctly mark all web tests.
Skip test which needs pytest.warns module.
Skip selected tests when run as root.
Adjust requires accordingly, add missing `git-core`.