### PR TITLE
Fix warnings in pytest

### DIFF
--- a/fmf.spec
+++ b/fmf.spec
@@ -135,9 +135,9 @@ export LANG=en_US.utf-8
 %endif
 
 %if %{with python2}
-%{__python2} -m pytest -vv -m 'not web'
+%{__python2} -m pytest -vv -c tests/unit/pytest.ini -m 'not web'
 %else
-%{__python3} -m pytest -vv -m 'not web'
+%{__python3} -m pytest -vv -c tests/unit/pytest.ini -m 'not web'
 %endif
 
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -348,20 +348,17 @@ class TestRemote(object):
                 all_good = False
         assert all_good
 
-    def test_tree_concurrent_timeout(self, monkeypatch, tmpdir):
+    def test_tree_concurrent_timeout(self, monkeypatch):
         # Much shorter timeout
         monkeypatch.setattr('fmf.utils.NODE_LOCK_TIMEOUT', 2)
 
         def long_fetch(*args, **kwargs):
             # Longer than timeout
             time.sleep(7)
-            return str(tmpdir)
-
-        # Prepare some content in the repo
-        tmpdir.join('main.fmf').write('test: echo yes')
+            return EXAMPLES
 
         # Patch fetch to sleep and later return tmpdir path
-        monkeypatch.setattr('fmf.utils.fetch', long_fetch)
+        monkeypatch.setattr('fmf.utils.fetch_repo', long_fetch)
 
         # Background thread to get node() acquiring lock
         def target():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -339,11 +339,15 @@ class TestFetch(object):
         monkeypatch.setattr('fmf.utils.FETCH_LOCK_TIMEOUT', 2)
 
         def long_run(*args, **kwargs):
-            # Longer than timeout
-            time.sleep(7)
+            # Runs several times inside fetch so it is longer than timeout
+            time.sleep(2)
+
+        def no_op(*args, **kwargs):
+            pass
 
         # Patch run to use sleep instead
         monkeypatch.setattr('fmf.utils.run', long_run)
+        monkeypatch.setattr('fmf.utils.shutil.copyfile', no_op)
 
         # Background thread to fetch_repo() the same destination acquiring lock
         def target():


### PR DESCRIPTION
- Use pytest.ini during rpm build %check

- Avoid raising exceptions during concurrency tests