### PR TITLE
Use a deep copy when storing raw node data

### DIFF
--- a/fmf/base.py
+++ b/fmf/base.py
@@ -318,7 +318,7 @@ class Tree(object):
 
         # Adjust rules should be a dictionary or a list of dictionaries
         try:
-            rules = self.data.pop(key)
+            rules = copy.deepcopy(self.data[key])
             log.debug("Applying adjust rules for '{}'.".format(self))
             log.data(rules)
             if isinstance(rules, dict):

--- a/fmf/base.py
+++ b/fmf/base.py
@@ -419,7 +419,7 @@ class Tree(object):
         # Save source file
         if source is not None:
             self.children[name].sources.append(source)
-            self.children[name]._raw_data = data
+            self.children[name]._raw_data = copy.deepcopy(data)
 
     def grow(self, path):
         """
@@ -466,7 +466,7 @@ class Tree(object):
             # Handle main.fmf as data for self
             if filename == MAIN:
                 self.sources.append(fullpath)
-                self._raw_data = data
+                self._raw_data = copy.deepcopy(data)
                 self.update(data)
             # Handle other *.fmf files as children
             else:

--- a/fmf/utils.py
+++ b/fmf/utils.py
@@ -17,7 +17,7 @@ from pprint import pformat as pretty
 import yaml
 import warnings
 # Use six only on python2
-if sys.version[0] == '2':
+if sys.version[0] == '2': # pragma: no cover
     from six import StringIO
 else:
     from io import StringIO

--- a/tests/unit/test_adjust.py
+++ b/tests/unit/test_adjust.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 
 from __future__ import unicode_literals, absolute_import
+
+import copy
 import pytest
 import yaml
 
@@ -122,6 +124,11 @@ class TestAdjust(object):
     def test_adjusted(self, mini, centos):
         mini.adjust(centos)
         assert mini.get('enabled') is False
+
+    def test_keep_original_adjust_rules(self, mini, centos):
+        original_adjust = copy.deepcopy(mini.get('adjust'))
+        mini.adjust(centos)
+        assert mini.get('adjust') == original_adjust
 
     def test_skipped(self, mini, fedora):
         mini.adjust(fedora)

--- a/tests/unit/test_modify.py
+++ b/tests/unit/test_modify.py
@@ -10,6 +10,7 @@ import re
 import tempfile
 
 from fmf.base import Tree
+from fmf.context import Context
 from fmf.utils import GeneralError
 from shutil import rmtree, copytree
 
@@ -156,3 +157,15 @@ class TestModify(unittest.TestCase):
         reloaded = Tree(self.tempdir).find('/unicode')
         assert reloaded.get('jméno') == 'Leoš'
         assert reloaded.get('příjmení') == 'Janáček'
+
+    def test_modify_after_adjust(self):
+        """ Preserve original data even when adjust is used """
+        item = '/requirements/protocols/ftp'
+        wget = Tree(self.tempdir)
+        # Expects new attribute + original data
+        expected = {'new_attr': "new_value"}
+        expected.update(wget.find(item).copy().get())
+        wget.adjust(Context(arch='ppc64le'))
+        with wget.find(item) as data:
+            data['new_attr'] = "new_value"
+        assert expected == Tree(self.tempdir).find(item).get()

--- a/tests/unit/test_modify.py
+++ b/tests/unit/test_modify.py
@@ -132,9 +132,7 @@ class TestModify(unittest.TestCase):
                 data['y'] = 2
 
     def test_context_manager(self):
-        """
-        try to use context manager for save node data
-        """
+        """ Use context manager to save node data """
         item = '/requirements/protocols/ftp'
         with self.wget.find(item) as data:
             data.pop("coverage")


### PR DESCRIPTION
When the `adjust()` method is used it can modify data referenced
from the raw data dictionaries. Make a deep copy to ensure the
original data are preserved.

- [ ] add test coverage