### PR TITLE
Disable integration testing with tmt for centos-7

### DIFF
--- a/plans/integration.fmf
+++ b/plans/integration.fmf
@@ -8,3 +8,6 @@ discover:
 prepare:
     how: install
     package: tmt-all
+adjust:
+    enabled: false
+    when: distro == centos-7


### PR DESCRIPTION
This will be working once `tmt-1.4` is deployed in the pipeline. Let's wait with the merge until @thrix pulls the fresh `tmt` to confirm it's working as expected.