### PR TITLE
Add extra requires and enable readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,7 @@
+# Config for building https://fmf.readthedocs.io/
+version: 2
+python:
+    install:
+      - method: pip
+        path: .
+        extra_requirements: [docs]

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -76,6 +76,11 @@ your commits to the project::
     pip install pre-commit
     pre-commit install
 
+Or simply install all extra dependencies to make sure you have
+everything needed for the development ready on your system::
+
+    pip install '.[all]'
+
 
 Makefile
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -121,7 +126,7 @@ To run tests using pytest with the test coverage overview::
 Install pytest and coverage using dnf or pip::
 
     dnf install python3-pytest python3-coverage
-    pip install pytest coveralls
+    pip install .[tests]
 
 
 Docs
@@ -129,7 +134,7 @@ Docs
 
 For building documentation locally install necessary modules::
 
-    pip install sphinx sphinx_rtd_theme mock
+    pip install .[docs]
 
 Make sure docutils are installed in order to build man pages::
 

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,20 @@ __pkgs__ = ['fmf']
 __provides__ = ['fmf']
 __desc__ = 'Flexible Metadata Format'
 __scripts__ = ['bin/fmf']
-__irequires__ = [
+
+# Prepare install requires and extra requires
+install_requires = [
     'PyYAML',
     'filelock'
-]
+    ]
+extras_require = {
+    'docs': ['sphinx>=3', 'sphinx_rtd_theme'],
+    'tests': ['pytest', 'python-coveralls', 'pre-commit'],
+    }
+extras_require['all'] = [
+    dependency
+    for extra in extras_require.values()
+    for dependency in extra]
 
 pip_src = 'https://pypi.python.org/packages/source'
 __deplinks__ = []
@@ -56,7 +66,8 @@ default_setup = dict(
     keywords=['metadata', 'testing'],
     dependency_links=__deplinks__,
     description=__desc__,
-    install_requires=__irequires__,
+    install_requires=install_requires,
+    extras_require=extras_require,
     name=__pkg__,
     package_dir=__pkgdir__,
     packages=__pkgs__,


### PR DESCRIPTION
Extend `setup.py` with extra requires, update the contribute page
accordingly. Enable readthedocs config with the docs requires.