### PR TITLE
Drop support for Python 2

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -18,7 +18,6 @@ jobs:
       targets:
       - fedora-all
       - epel-8
-      - epel-7
 
   - job: copr_build
     trigger: commit
@@ -27,7 +26,6 @@ jobs:
       targets:
       - fedora-all
       - epel-8
-      - epel-7
       list_on_homepage: True
       preserve_project: True
       owner: psss

--- a/docs/concept.rst
+++ b/docs/concept.rst
@@ -70,7 +70,8 @@ files on the filesystem:
 * main.fmf
 
 Special file name ``main.fmf`` works similarly as ``index.html``.
-It can be used to define the top level data for the directory.
+It can be used to define the top level data for the directory. All
+metadata files are expected to be using the ``utf-8`` encoding.
 
 
 Attributes

--- a/fmf.spec
+++ b/fmf.spec
@@ -9,30 +9,8 @@ BuildArch: noarch
 URL: https://github.com/psss/fmf
 Source0: https://github.com/psss/fmf/releases/download/%{version}/fmf-%{version}.tar.gz
 
-# Depending on the distro, we set some defaults.
-# Note that the bcond macros are named for the CLI option they create.
-# "%%bcond_without" means "ENABLE by default and create a --without option"
-
-# Fedora or RHEL 8+
-%if 0%{?fedora} || 0%{?rhel} > 7
-%bcond_with python2
-%bcond_with oldreqs
-%bcond_with englocale
-# RHEL 7
-%else
-%bcond_without python2
-# The automatic runtime dependency generator doesn't exist yet
-%bcond_without oldreqs
-# The C.UTF-8 locale doesn't exist, Python defaults to C (ASCII)
-%bcond_without englocale
-%endif
-
-# Main tmt package requires the Python module
-%if %{with python2}
-Requires: python2-%{name} == %{version}-%{release}
-%else
+# Main fmf package requires the Python module
 Requires: python%{python3_pkgversion}-%{name} == %{version}-%{release}
-%endif
 
 %description
 The fmf Python module and command line tool implement a flexible
@@ -45,34 +23,6 @@ This package contains the command line tool.
 %?python_enable_dependency_generator
 
 
-# Python 2
-%if %{with python2}
-%package -n     python2-%{name}
-Summary:        %{summary}
-BuildRequires: python2-devel
-BuildRequires: python2-setuptools
-BuildRequires: pytest
-BuildRequires: PyYAML
-BuildRequires: python2-filelock
-BuildRequires: python2-six
-BuildRequires: git-core
-%{?python_provide:%python_provide python2-%{name}}
-Requires:       PyYAML
-Requires:       python2-filelock
-Requires:       python2-six
-Requires:       git-core
-
-%description -n python2-%{name}
-The fmf Python module and command line tool implement a flexible
-format for defining metadata in plain text files which can be
-stored close to the source code. Thanks to hierarchical structure
-with support for inheritance and elasticity it provides an
-efficient way to organize data into well-sized text documents.
-This package contains the Python 2 module.
-%else
-
-
-# Python 3
 %package -n     python%{python3_pkgversion}-%{name}
 Summary:        %{summary}
 BuildRequires: python%{python3_pkgversion}-devel
@@ -83,10 +33,6 @@ BuildRequires: python%{python3_pkgversion}-filelock
 BuildRequires: git-core
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{name}}
 Requires:       git-core
-%if %{with oldreqs}
-Requires:       python%{python3_pkgversion}-PyYAML
-Requires:       python%{python3_pkgversion}-filelock
-%endif
 
 %description -n python%{python3_pkgversion}-%{name}
 The fmf Python module and command line tool implement a flexible
@@ -95,7 +41,6 @@ stored close to the source code. Thanks to hierarchical structure
 with support for inheritance and elasticity it provides an
 efficient way to organize data into well-sized text documents.
 This package contains the Python 3 module.
-%endif
 
 
 %prep
@@ -103,42 +48,17 @@ This package contains the Python 3 module.
 
 
 %build
-%if %{with englocale}
-export LANG=en_US.utf-8
-%endif
-
-%if %{with python2}
-%py2_build
-%else
 %py3_build
-%endif
 
 
 %install
-%if %{with englocale}
-export LANG=en_US.utf-8
-%endif
-
-%if %{with python2}
-%py2_install
-%else
 %py3_install
-%endif
-
 mkdir -p %{buildroot}%{_mandir}/man1
 install -pm 644 fmf.1* %{buildroot}%{_mandir}/man1
 
 
 %check
-%if %{with englocale}
-export LANG=en_US.utf-8
-%endif
-
-%if %{with python2}
-%{__python2} -m pytest -vv -c tests/unit/pytest.ini -m 'not web'
-%else
 %{__python3} -m pytest -vv -c tests/unit/pytest.ini -m 'not web'
-%endif
 
 
 %{!?_licensedir:%global license %%doc}
@@ -149,17 +69,10 @@ export LANG=en_US.utf-8
 %doc README.rst examples
 %license LICENSE
 
-%if %{with python2}
-%files -n python2-%{name}
-%{python2_sitelib}/%{name}/
-%{python2_sitelib}/%{name}-*.egg-info
-%license LICENSE
-%else
 %files -n python%{python3_pkgversion}-%{name}
 %{python3_sitelib}/%{name}/
 %{python3_sitelib}/%{name}-*.egg-info
 %license LICENSE
-%endif
 
 
 %changelog

--- a/fmf/__init__.py
+++ b/fmf/__init__.py
@@ -1,7 +1,5 @@
 """ Flexible Metadata Format """
 
-from __future__ import absolute_import, unicode_literals
-
 from fmf.base import Tree
 from fmf.utils import filter
 

--- a/fmf/base.py
+++ b/fmf/base.py
@@ -1,8 +1,4 @@
-# coding: utf-8
-
 """ Base Metadata Classes """
-
-from __future__ import absolute_import, unicode_literals
 
 import copy
 import os
@@ -70,7 +66,7 @@ YamlLoader.add_constructor(
 #  Metadata
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-class Tree(object):
+class Tree:
     """ Metadata Tree """
 
     def __init__(self, data, name=None, parent=None):
@@ -151,9 +147,9 @@ class Tree(object):
             self._commit = False
         return self._commit
 
-    def __unicode__(self):
+    def __str__(self):
         """ Use tree name as identifier """
-        return self.name  # pragma: no cover
+        return self.name
 
     def _initialize(self, path):
         """ Find metadata tree root, detect format version """

--- a/fmf/cli.py
+++ b/fmf/cli.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 """
 This is command line interface for the Flexible Metadata Format.
 
@@ -18,8 +16,6 @@ Check also help message of individual commands for the full list
 of available options.
 """
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import argparse
 import os
 import os.path
@@ -34,7 +30,7 @@ import fmf.utils as utils
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
-class Parser(object):
+class Parser:
     """ Command line options parser """
 
     def __init__(self, arguments=None, path=None):
@@ -43,20 +39,11 @@ class Parser(object):
         if path is not None:
             os.chdir(path)
         # Split command line if given as a string (used for testing)
-        if isinstance(arguments, type("")):  # pragma: no cover
-            try:
-                # This is necessary for Python 2.6
-                self.arguments = [
-                    arg.decode('utf8') for arg in shlex.split(
-                        arguments.encode('utf8'))]
-            except AttributeError:
-                self.arguments = shlex.split(arguments)
-        # Otherwise use sys.argv (plus decode unicode for Python 2)
-        if arguments is None:  # pragma: no cover
-            try:
-                self.arguments = [arg.decode("utf-8") for arg in sys.argv]
-            except AttributeError:
-                self.arguments = sys.argv
+        if isinstance(arguments, str):
+            self.arguments = shlex.split(arguments)
+        # Otherwise use sys.argv
+        if arguments is None:
+            self.arguments = sys.argv
         # Enable debugging output if requested
         if "--debug" in self.arguments:
             utils.log.setLevel(utils.LOG_DEBUG)
@@ -182,10 +169,7 @@ class Parser(object):
             joined = "".join(output)
         else:
             joined = "\n".join(output)
-        try:  # pragma: no cover
-            print(joined, end="")
-        except UnicodeEncodeError:  # pragma: no cover
-            print(joined.encode('utf-8'), end="")
+        print(joined, end="")
         if self.options.verbose:
             utils.info("Found {0}.".format(
                 utils.listed(len(output), "object")))

--- a/fmf/context.py
+++ b/fmf/context.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 All you need to decide if Context matches
 
@@ -32,7 +31,7 @@ class InvalidContext(Exception):
     pass
 
 
-class ContextValue(object):
+class ContextValue:
     """ Value for dimension """
 
     def __init__(self, origin):
@@ -182,7 +181,7 @@ class ContextValue(object):
         return hash(self._to_compare)
 
 
-class Context(object):
+class Context:
     """ Represents https://fmf.readthedocs.io/en/latest/context.html """
     # Operators' definitions
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 import re
 from io import open

--- a/tests/unit/main.fmf
+++ b/tests/unit/main.fmf
@@ -6,8 +6,3 @@ framework: shell
 require:
   - python3-pytest
 tier: 0
-
-adjust:
-    test: python2 -m pytest -v
-    require: python2-pytest
-    when: distro == rhel-7, centos-7

--- a/tests/unit/test_adjust.py
+++ b/tests/unit/test_adjust.py
@@ -1,7 +1,3 @@
-# coding: utf-8
-
-from __future__ import absolute_import, unicode_literals
-
 import copy
 
 import pytest
@@ -73,7 +69,7 @@ def full():
     return fmf.Tree(yaml.safe_load(data))
 
 
-class TestInvalid(object):
+class TestInvalid:
     """ Ensure that invalid input is correctly handled """
 
     def test_invalid_context(self, mini):
@@ -106,7 +102,7 @@ class TestInvalid(object):
             mini.adjust(fedora, undecided='weird')
 
 
-class TestSpecial(object):
+class TestSpecial:
     """ Check various special cases """
 
     def test_single_rule(self, mini, fedora):
@@ -118,7 +114,7 @@ class TestSpecial(object):
         assert mini.get() == dict(enabled=True)
 
 
-class TestAdjust(object):
+class TestAdjust:
     """ Verify adjusting works as expected """
 
     def test_original(self, mini):

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -1,8 +1,5 @@
-# coding: utf-8
-
-from __future__ import absolute_import, unicode_literals
-
 import os
+import queue
 import tempfile
 import threading
 import time
@@ -13,12 +10,6 @@ import pytest
 import fmf.cli
 import fmf.utils as utils
 from fmf.base import Tree
-
-try:
-    import queue
-except ImportError:
-    import Queue as queue
-
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Constants
@@ -34,7 +25,7 @@ FMF_REPO = 'https://github.com/psss/fmf.git'
 #  Tree
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-class TestTree(object):
+class TestTree:
     """ Tree class """
 
     def setup_method(self, method):
@@ -260,7 +251,7 @@ class TestTree(object):
         assert original.get('x') is None
 
 
-class TestRemote(object):
+class TestRemote:
     """ Get tree node data using remote reference """
 
     @pytest.mark.web

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,7 +1,3 @@
-# coding: utf-8
-
-from __future__ import absolute_import, unicode_literals
-
 import os
 import sys
 import tempfile
@@ -16,7 +12,7 @@ PATH = os.path.dirname(os.path.realpath(__file__))
 WGET = PATH + "/../../examples/wget"
 
 
-class TestCommandLine(object):
+class TestCommandLine:
     """ Command Line """
 
     def test_smoke(self):

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1,7 +1,3 @@
-# coding: utf-8
-
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from fmf.context import (CannotDecide, Context, ContextValue, InvalidContext,
@@ -17,7 +13,7 @@ def env_centos():
         )
 
 
-class TestExample(object):
+class TestExample:
     """ Examples of possible conditions """
 
     def test_simple_conditions(self, env_centos):
@@ -237,7 +233,7 @@ class TestExample(object):
             Context("module = perl:6.28").matches("module ~>= perl:5.28")
 
 
-class TestContextValue(object):
+class TestContextValue:
     impossible_split = ["x86_64", "ppc64", "fips", "errata"]
     splittable = [
         ("centos-8.3.0", ("centos", "8", "3", "0")),
@@ -377,7 +373,7 @@ class TestContextValue(object):
         assert ContextValue.compare("8", "19") == -1
 
 
-class TestParser(object):
+class TestParser:
     # Missing expression
     rule_groups_invalid = ["foo<bar and ", "foo<bar and defined bar or "]
 
@@ -458,7 +454,7 @@ class TestParser(object):
                 ("dim", "!=", [ContextValue("valueC")])]]
 
 
-class TestContext(object):
+class TestContext:
     def test_creation(self):
         for created in [
                 Context(dim_a="value", dim_b=["val"], dim_c=["foo", "bar"]),
@@ -717,7 +713,7 @@ class TestContext(object):
             "{0} or {1} and {2}".format(_false, _cannot, _false))
 
 
-class TestOperators(object):
+class TestOperators:
     """ more thorough testing for operations """
 
     context = Context(

--- a/tests/unit/test_items.py
+++ b/tests/unit/test_items.py
@@ -1,7 +1,3 @@
-# coding: utf-8
-
-from __future__ import absolute_import, unicode_literals
-
 import os
 import unittest
 

--- a/tests/unit/test_modify.py
+++ b/tests/unit/test_modify.py
@@ -1,7 +1,3 @@
-# coding: utf-8
-
-from __future__ import absolute_import, unicode_literals
-
 import io
 import os
 import re

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -1,7 +1,3 @@
-# coding: utf-8
-
-from __future__ import absolute_import, unicode_literals
-
 import os
 
 import fmf.cli
@@ -11,7 +7,7 @@ PATH = os.path.dirname(os.path.realpath(__file__))
 WGET = PATH + "/../../examples/wget"
 
 
-class TestSmoke(object):
+class TestSmoke:
     """ Smoke Test """
 
     def test_smoke(self):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,8 +1,5 @@
-# coding: utf-8
-
-from __future__ import absolute_import, unicode_literals
-
 import os
+import queue
 import shutil
 import threading
 import time
@@ -12,17 +9,11 @@ import pytest
 import fmf.utils as utils
 from fmf.utils import filter, listed, run
 
-try:
-    import queue
-except ImportError:
-    import Queue as queue
-
-
 GIT_REPO = 'https://github.com/psss/fmf.git'
 GIT_REPO_MAIN = 'https://github.com/beakerlib/example'
 
 
-class TestFilter(object):
+class TestFilter:
     """ Function filter() """
 
     def setup_method(self, method):
@@ -105,7 +96,7 @@ class TestFilter(object):
         assert(filter("tag: -ťop", {"tag": ["ťip"]}) is True)
 
 
-class TestPluralize(object):
+class TestPluralize:
     """ Function pluralize() """
 
     def test_basic(self):
@@ -114,7 +105,7 @@ class TestPluralize(object):
         assert(utils.pluralize("boss") == "bosses")
 
 
-class TestListed(object):
+class TestListed:
     """ Function listed() """
 
     def test_basic(self):
@@ -134,7 +125,7 @@ class TestListed(object):
         assert(listed(0, "item") == "0 items")
 
 
-class TestSplit(object):
+class TestSplit:
     """ Function split() """
 
     def test_basic(self):
@@ -143,7 +134,7 @@ class TestSplit(object):
         assert(utils.split(['a, b', 'c']) == ['a', 'b', 'c'])
 
 
-class TestLogging(object):
+class TestLogging:
     """ Logging """
 
     def test_level(self):
@@ -161,7 +152,7 @@ class TestLogging(object):
         utils.log.all("all")
 
 
-class TestColoring(object):
+class TestColoring:
     """ Coloring """
 
     def test_invalid(self):
@@ -178,7 +169,7 @@ class TestColoring(object):
         text = utils.color("text", "lightblue", enabled=True)
 
 
-class TestCache(object):
+class TestCache:
     """ Local cache manipulation """
 
     def test_clean_cache_directory(self, tmpdir):
@@ -196,7 +187,7 @@ class TestCache(object):
 
 
 @pytest.mark.web
-class TestFetch(object):
+class TestFetch:
     """ Remote reference from fmf github """
 
     def test_fetch_default_branch(self):


### PR DESCRIPTION
Remove related stuff from the spec file.
Remove Python 2 only code, disable epel-7 packit.
Remove irrelevant adjust rule from unit tests.
Get rid of other `unicode` related leftovers.
Use default encoding for running commands.
Explicitly mention the `utf-8` encoding in the docs.
Remove unnecessary `object` from class definitions.