### PR TITLE
Migrate yaml parsing to ruamel.yaml, remove hacks

### DIFF
--- a/fmf.spec
+++ b/fmf.spec
@@ -28,7 +28,7 @@ Summary:        %{summary}
 BuildRequires: python%{python3_pkgversion}-devel
 BuildRequires: python%{python3_pkgversion}-setuptools
 BuildRequires: python%{python3_pkgversion}-pytest
-BuildRequires: python%{python3_pkgversion}-PyYAML
+BuildRequires: python%{python3_pkgversion}-ruamel-yaml
 BuildRequires: python%{python3_pkgversion}-filelock
 BuildRequires: git-core
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{name}}

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ __scripts__ = ['bin/fmf']
 
 # Prepare install requires and extra requires
 install_requires = [
-    'PyYAML',
+    'ruamel.yaml',
     'filelock'
     ]
 extras_require = {

--- a/tests/unit/test_adjust.py
+++ b/tests/unit/test_adjust.py
@@ -1,7 +1,7 @@
 import copy
 
 import pytest
-import yaml
+from ruamel.yaml import YAML
 
 import fmf
 from fmf.context import CannotDecide, Context
@@ -29,7 +29,8 @@ def mini():
             enabled: false
             when: distro = centos
         """
-    return fmf.Tree(yaml.safe_load(data))
+    yaml = YAML(typ="safe")
+    return fmf.Tree(yaml.load(data))
 
 
 @pytest.fixture
@@ -66,7 +67,8 @@ def full():
               - require+: [three]
                 when: distro = fedora
         """
-    return fmf.Tree(yaml.safe_load(data))
+    yaml = YAML(typ="safe")
+    return fmf.Tree(yaml.load(data))
 
 
 class TestInvalid:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -6,6 +6,7 @@ import time
 
 import pytest
 
+import fmf
 import fmf.utils as utils
 from fmf.utils import filter, listed, run
 
@@ -415,3 +416,13 @@ class TestFetch:
         assert os.path.isfile(fetch_head)
         utils.invalidate_cache()
         assert not os.path.isfile(fetch_head)
+
+
+class TestDictToYaml:
+    """ Verify dictionary to yaml format conversion """
+
+    def test_sort(self):
+        """ Verify key sorting """
+        data = dict(y=2, x=1)
+        assert fmf.utils.dict_to_yaml(data) == "y: 2\nx: 1\n"
+        assert fmf.utils.dict_to_yaml(data, sort=True) == "x: 1\ny: 2\n"


### PR DESCRIPTION
Migrate yaml parsing code to `ruamel.yaml`.
Update spec file and `setup.py` accordingly.
Remove a bunch of old hacks, adjust tests.